### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/carlkidcrypto/os-specific-runner/security/code-scanning/4](https://github.com/carlkidcrypto/os-specific-runner/security/code-scanning/4)

To fix this problem, you should add a `permissions` block explicitly to the workflow as specified in the CodeQL recommendation and best security practices. The most minimal fix is to add `permissions: contents: read` at the root level of the workflow file (above `jobs:`) to apply it to all jobs. This change does not alter any workflow behavior but instead limits the abilities granted to the GITHUB_TOKEN, following least privilege principles. Edit `.github/workflows/tests.yml`, inserting the `permissions:` block after the workflow name and before the `on:` block (as per best practice). No additional imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
