### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -1,5 +1,8 @@
 name: regenerate
 
+permissions:
+  contents: write
+
 on:
   pull_request:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/carlkidcrypto/os-specific-runner/security/code-scanning/6](https://github.com/carlkidcrypto/os-specific-runner/security/code-scanning/6)

To fix this problem, add a `permissions` block to the workflow, specifying only the minimal privileges required for the job. Since the workflow uses an action to commit the regenerated file (`dist/index.js`), it needs `contents: write` permission to push changes to the repository, but other permissions are not needed. The change should be applied near the top of the workflow file, immediately after the `name` block and before the jobs definition. No external libraries or extensive code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
